### PR TITLE
Update index.js for xdrip+ info

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -40,15 +40,16 @@ function defaults ( ) {
     , A52_risk_enable: false
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets
-    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre, or similar
-    // LimiTTer, etc. do not properly filter out high-noise SGVs.  Xdrip+ builds greater than or equal to
-    // version number d8e-7097-2018-01-22 filters out high noise and restricts via high temp target for medium noise,
-    // resulting in appropriate SMB behaviour.  Older versions of Xdrip+ should not be used with enableSMB_always.
+    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre or similar
+    // LimiTTer, etc. do not properly filter out high-noise SGVs.  xDrip+ builds greater than or equal to
+    // version number d8e-7097-2018-01-22 provide proper noise values, so that oref0 can ignore high noise
+    // readings, and can temporarily raise the BG target when sensor readings have medium noise,
+    // resulting in appropriate SMB behaviour.  Older versions of xDrip+ should not be used with enableSMB_always.
     // Using SMB overnight with such data sources risks causing a dangerous overdose of insulin
     // if the CGM sensor reads falsely high and doesn't come down as actual BG does
     , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
-    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre, or similar.
+    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre or similar.
     , allowSMB_with_high_temptarget: false // allow supermicrobolus (if otherwise enabled) even with high temp targets
     , maxSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB with uncovered COB
     , curve: "rapid-acting" // change this to "ultra-rapid" for Fiasp, or "bilinear" for old curve

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -40,13 +40,15 @@ function defaults ( ) {
     , A52_risk_enable: false
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets
-    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with xDrip+, Libre, or similar
-    // xDrip+, LimiTTer, etc. do not properly filter out high-noise SGVs
+    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre, or similar
+    // LimiTTer, etc. do not properly filter out high-noise SGVs.  Xdrip+ builds greater than or equal to
+    // version number d8e-7097-2018-01-22 filters out high noise and restricts via high temp target for medium noise,
+    // resulting in appropriate SMB behaviour.  Older versions of Xdrip+ should not be used with enableSMB_always.
     // Using SMB overnight with such data sources risks causing a dangerous overdose of insulin
     // if the CGM sensor reads falsely high and doesn't come down as actual BG does
     , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
-    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with xDrip+, Libre, or similar
+    // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre, or similar.
     , allowSMB_with_high_temptarget: false // allow supermicrobolus (if otherwise enabled) even with high temp targets
     , maxSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB with uncovered COB
     , curve: "rapid-acting" // change this to "ultra-rapid" for Fiasp, or "bilinear" for old curve


### PR DESCRIPTION
Fix to warning message indicating Xdrip+ version version number d8e-7097-2018-01-22 or greater can handle noisy data appropriately.