### PR TITLE
added extra 'esc' to pump loop to avoid A52

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -256,8 +256,8 @@ function smb_bolus {
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json 2>/dev/null); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
-        echo -n "Sending ESC ESC ESC to exit any open menus before SMBing: "
-        try_return openaps use pump press_keys esc esc esc | jq .completed | grep true \
+        echo -n "Sending ESC ESC ESC ESC to exit any open menus before SMBing: "
+        try_return openaps use pump press_keys esc esc esc esc | jq .completed | grep true \
         && try_return openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json


### PR DESCRIPTION
Added an extra 'esc' to pump loop to avoid A52 error bringing the total to 4.  I think this will bring the pump back to the BW main screen which should be sufficient to avoid the error.